### PR TITLE
Removed need for "quotes" around names with spaces

### DIFF
--- a/leaguecog/blitzcrank.py
+++ b/leaguecog/blitzcrank.py
@@ -1,8 +1,14 @@
 import asyncio
+import logging
 
 import aiohttp
 import discord
 from redbot.core import Config
+
+
+### DEBUG ###
+log = logging.getLogger("red.creamy-cogs.leaguecog")
+logging.disable(logging.CRITICAL)
 
 
 class Blitzcrank:
@@ -13,7 +19,6 @@ class Blitzcrank:
     # To-Do:
     #   Move all standard API call logic into one function to call
     #   Warn user with instructions on how to set API key if it is invalid.
-    #   Catch and warn if they try to input summoner with space, no quotes.
 
     def __init__(self, bot):
         self.api = None
@@ -108,17 +113,22 @@ class Blitzcrank:
             region = self.regions[region.lower()]
 
         except KeyError:
+            # raise a KeyError for bad region, pass title, type, and message to build_embed()
+            #    and send the author a formatted list of available regions
             currTitle = "Invalid Region"
             currType = "invalidRegion"
-            currMsg = f"Region {region.upper()} not found. Available regions:\n" + ", ".join(
-                [r.upper() for r in self.regions.keys()]
+            currMsg = (
+                f"Region {region.upper()} not found. Available regions:\n"
+                + ", ".join([r.upper() for r in self.regions.keys()])
             )
 
         else:
             async with aiohttp.ClientSession() as session:
-                async with session.get(
-                    f"https://{region}.api.riotgames.com/lol/summoner/v4/summoners/by-name/{name}/{apiAuth}"
-                ) as req:
+                # build the url as an f-string, can double-check 'name' in the console
+                url = f"https://{region}.api.riotgames.com/lol/summoner/v4/summoners/by-name/{name}/{apiAuth}"
+                log.info(f"url == {url}")
+
+                async with session.get(url) as req:
                     try:
                         data = await req.json()
                     except aiohttp.ContentTypeError:

--- a/leaguecog/leaguecog.py
+++ b/leaguecog/leaguecog.py
@@ -1,8 +1,15 @@
+import logging
+
 import discord
 from redbot.core import commands, Config
 from redbot.core.bot import Red
 
 from .blitzcrank import Blitzcrank
+
+
+### DEBUG ###
+log = logging.getLogger("red.creamy-cogs")
+logging.disable(logging.CRITICAL)
 
 
 class LeagueCog(commands.Cog):
@@ -45,16 +52,12 @@ class LeagueCog(commands.Cog):
             member = ctx.author
             name = await self.config.member(member).summoner()
             region = await self.config.member(member).region()
-            await ctx.send(
-                f"Your summoner name is {name}, located in {region}."
-            )
+            await ctx.send(f"Your summoner name is {name}, located in {region}.")
 
         else:
             name = await self.config.member(member).summoner()
             if name:
-                await ctx.send(
-                    f"That user's summoner name is {name}."
-                )
+                await ctx.send(f"That user's summoner name is {name}.")
             else:
                 await ctx.send("That user does not have a summoner name setup yet.")
 
@@ -63,20 +66,31 @@ class LeagueCog(commands.Cog):
         """Base command to manage League settings"""
 
     @leagueset.command(name="summoner")
-    async def set_summoner(
-        self, ctx: commands.Context, name: str = "", region: str = None
-    ):
+    async def set_summoner(self, ctx: commands.Context, *args):
         """
-        This sets your summoner name to your account.
-        Names with spaces must be enclosed in "quotes." Region is optional.
+        This sets your summoner name to your account. Region is optional.
         If you don't pass a region, it will use your currently assigned region.
         If you don't have a currently assigned region, it will use the default for the guild.
 
         Example:
             [p]leagueset summoner your_summoner_name NA
+            [p]leagueset summoner firstname lastname na
         """
         author = ctx.author
+        # use the consumer '*args' to capture all the groups in the command
+        #   if the length of args is 3, the user has entered a name with a space,
+        #       by catching this ValueError, quotes aren't necessary
+        try:
+            name, region = args
+        except ValueError:
+            name1, name2, region = args
+            # add back the space that was input by the user
+            name = name1 + " " + name2
+
         name = name.strip()
+
+        log.info(f"args == {args}")
+        log.info(f"name == {name}, region == {region}")
 
         # If they did not pass a region, don't change their region if they have one set.
         # If they don't have one set, use the guild's default.
@@ -87,5 +101,3 @@ class LeagueCog(commands.Cog):
 
         # See if summoner name exists on that region.
         await Blitzcrank(self.bot).get_summoner_info(ctx, name, region)
-
-    # Change region (check vs approved)


### PR DESCRIPTION
* rather than parsing `name` and `region` from the command, consume the whole string as a tuple with `*args`
* added logging calls, disabled for PR
* added comments for last PR changes
* removed old comments that no longer apply
* other minor formatting with `black`