### PR TITLE
Walk the user through setting up some basic cog settings

### DIFF
--- a/leaguecog/blitzcrank.py
+++ b/leaguecog/blitzcrank.py
@@ -1,10 +1,12 @@
 import asyncio
 import logging
+
 import aiohttp
 import discord
 from redbot.core import Config
 
-from leaguecog.mixinmeta import MixinMeta
+from .mixinmeta import MixinMeta
+
 
 log = logging.getLogger("red.creamy-cogs.leaguecog")
 

--- a/leaguecog/blitzcrank.py
+++ b/leaguecog/blitzcrank.py
@@ -6,7 +6,7 @@ from redbot.core import Config
 
 from leaguecog.mixinmeta import MixinMeta
 
-log = logging.getLogger("red.creamy.cogs.league")
+log = logging.getLogger("red.creamy-cogs.leaguecog")
 
 
 class Blitzcrank(MixinMeta):
@@ -14,8 +14,8 @@ class Blitzcrank(MixinMeta):
     'The time of man has come to an end.'
 
     This class is responsible for:
-       1) handling the token for Riot API.
-       2) grabbing and pulling data from Riot API.
+        1) handling the token for Riot API.
+        2) grabbing and pulling data from Riot API.
     """
 
     async def get_riot_url(self, region):

--- a/leaguecog/ezreal.py
+++ b/leaguecog/ezreal.py
@@ -2,7 +2,7 @@ import logging
 import discord
 from leaguecog.mixinmeta import MixinMeta
 
-log = logging.getLogger("red.creamy.cogs.league")
+log = logging.getLogger("red.creamy-cogs.leaguecog")
 
 
 class Ezreal(MixinMeta):
@@ -12,7 +12,7 @@ class Ezreal(MixinMeta):
     This class is responsible for handling chat interactions with Discord.
     """
 
-    async def build_embed(self, title, msg, _type):
+    async def build_embed(self, title=None, msg=None, _type=None):
         embed = discord.Embed()
 
         if title:

--- a/leaguecog/ezreal.py
+++ b/leaguecog/ezreal.py
@@ -1,6 +1,9 @@
 import logging
+
 import discord
-from leaguecog.mixinmeta import MixinMeta
+
+from .mixinmeta import MixinMeta
+
 
 log = logging.getLogger("red.creamy-cogs.leaguecog")
 

--- a/leaguecog/leaguecog.py
+++ b/leaguecog/leaguecog.py
@@ -143,11 +143,18 @@ class LeagueCog(
     async def setup_cog(self, ctx: commands.Context):
         """
         Guides the user through setting up different cog settings
+
+        NOTE this is in dire need of refactoring
+
+        For example, I think it would be reasonable to define these predicates
+        as different functions, as this would enable us to let users go back
+        and reset different settings individually later on with something like
+        "[p]league setup --region"
         """
 
-        # TODO Setup Riot API key and request a permanent one.
+        ### SETUP RIOT API KEY ### TODO
 
-        # allow the user to react to set region
+        ### SET REGION ###
         region_embed = await Ezreal.build_embed(
             self,
             title="SETUP - REGION",
@@ -174,7 +181,7 @@ class LeagueCog(
         )
         await region_msg.edit(content=ctx.author.mention, embed=region_embed)
 
-        # allow the user to react to turn polling on or off
+        ### ENABLE POLLING OR LEAVE OFF ###
         polling_embed = await Ezreal.build_embed(
             self, title="SETUP - POLLING", msg="Do you want to poll for live games?"
         )
@@ -194,7 +201,7 @@ class LeagueCog(
         )
         await polling_msg.edit(content=ctx.author.mention, embed=polling_embed)
 
-        # allow the user to choose a channel for announcements
+        ### CHOOSE ANNOUCEMENT CHANNEL ###
         channel_embed = await Ezreal.build_embed(
             self,
             title="SETUP - ANNOUNCEMENT CHANNEL",


### PR DESCRIPTION
Easy settings via reactions.

## Feature changes: ##
`[p]league setup` allows the user to set the following:

1. `guild.default_region()`
2. `guild.poll_games()`
3. `guild.alertChannel()`

## Other changes ##

- changed `Ezreal` args to kwargs, default values are `None`
- minor `import` order changes

Closes #7 