### PR TITLE
Dynamic refresh timer (Zilean)

### DIFF
--- a/leaguecog/blitzcrank.py
+++ b/leaguecog/blitzcrank.py
@@ -208,7 +208,6 @@ class Blitzcrank(MixinMeta):
                     basePath, headers = await self.get_riot_url(user_data["region"])
                     if not basePath == "block":
                         url = f"{basePath}spectator/v4/active-games/by-summoner/{user_data['summoner_id']}"
-                        log.debug(channel)
                         async with self._session.get(url, headers=headers) as req:
                             try:
                                 game_data = await req.json()

--- a/leaguecog/leaguecog.py
+++ b/leaguecog/leaguecog.py
@@ -126,12 +126,10 @@ class LeagueCog(
     async def _game_alerts(self):
         """Loops every X seconds to see if list of registered summoners are in a game."""
         await self.bot.wait_until_ready()
-        zilean = Zilean()
         while True:
-            log.debug("Calculating loop interval...")
-            zilean.calculate_cooldown()
-            log.debug(f"zilean.cooldown == {zilean.cooldown}")
-            self.config.refresh_timer.set(zilean.cooldown)
+            await self.calculate_cooldown()
+            log.debug(f"self.cooldown == {self.cooldown}")
+            await self.config.refresh_timer.set(self.cooldown)
             log.debug("Checking games")
             await self.check_games()
             log.debug("Sleeping...")

--- a/leaguecog/leaguecog.py
+++ b/leaguecog/leaguecog.py
@@ -12,6 +12,7 @@ from redbot.core.utils.predicates import MessagePredicate, ReactionPredicate
 
 from .blitzcrank import Blitzcrank
 from .ezreal import Ezreal
+from .zilean import Zilean
 
 
 log = logging.getLogger("red.creamy-cogs.league")

--- a/leaguecog/leaguecog.py
+++ b/leaguecog/leaguecog.py
@@ -41,8 +41,6 @@ class LeagueCog(
 
     default_global_settings = {
         "notified_owner_missing_league_key": False,
-        # We should dynamically calculate this based on registered summoners to not hit throttle limit.
-        "refresh_timer": 30,
     }
 
     default_guild_settings = {

--- a/leaguecog/leaguecog.py
+++ b/leaguecog/leaguecog.py
@@ -30,6 +30,7 @@ class CompositeMetaClass(type(commands.Cog), type(ABC)):
 class LeagueCog(
     Blitzcrank,
     Ezreal,
+    Zilean,
     commands.Cog,
     metaclass=CompositeMetaClass,
 ):
@@ -125,7 +126,12 @@ class LeagueCog(
     async def _game_alerts(self):
         """Loops every X seconds to see if list of registered summoners are in a game."""
         await self.bot.wait_until_ready()
+        zilean = Zilean()
         while True:
+            log.debug("Calculating loop interval...")
+            zilean.calculate_cooldown()
+            log.debug(f"zilean.cooldown == {zilean.cooldown}")
+            self.config.refresh_timer.set(zilean.cooldown)
             log.debug("Checking games")
             await self.check_games()
             log.debug("Sleeping...")

--- a/leaguecog/leaguecog.py
+++ b/leaguecog/leaguecog.py
@@ -127,8 +127,9 @@ class LeagueCog(
         """Loops every X seconds to see if list of registered summoners are in a game."""
         await self.bot.wait_until_ready()
         while True:
+            # this is the main check games loop, so we can re-calculate our
+            #   refresh interval each loop through here and pick up new registrations
             await self.calculate_cooldown()
-            log.debug(f"self.cooldown == {self.cooldown}")
             await self.config.refresh_timer.set(self.cooldown)
             log.debug("Checking games")
             await self.check_games()

--- a/leaguecog/zilean.py
+++ b/leaguecog/zilean.py
@@ -1,0 +1,52 @@
+import asyncio
+import logging
+
+from .mixinmeta import MixinMeta
+
+
+log = logging.getLogger("red.creamy-cogs.league")
+
+
+class Zilean(MixinMeta):
+    """
+    'All in good time.'
+
+    This class dynamically calculates refresh time for the bot
+        based on registered summoners, so as to not hit throttle limit:
+            *  20 requests every 1 seconds(s)
+            *  100 requests every 2 minutes(s)
+
+    Note that the API token is used for the whole bot,
+        so if the bot is in multiple guilds, you have to take into account
+            total registered users across all guilds.
+
+    """
+
+    # The goal here to calculate the interval at leaguecog init
+    #   and then every time it loops through all the users
+    #       this will pick up new users that registered during
+    #           the last sleep window
+    async def calculate_refresh_interval(self, config):
+        total_registered_users = 0
+        guilds = await self.config.all_guilds()
+
+        log.info(f"guilds == {guilds}")
+
+        for guildId in guilds:
+            guild = await self.bot.fetch_guild(guildId)
+            poll_matches = await self.config.guild(guild).poll_games()
+            if poll_matches:
+                registered_users_in_guild = await self.config.all_members(guild=guild)
+            total_registered_users += registered_users_in_guild
+
+        log.info(f"total_registered_users == {total_registered_users}")
+
+        # leave bandwidth for some non-looping functions like set-summoner
+        #   and account for multiple requests in each loop
+        overhead_ratio = 0.75
+        reqs_per_loop = 3
+
+        self.refresh_time = (
+            (120 / (100 * overhead_ratio)) * total_registered_users
+        ) * reqs_per_loop
+        log.info(f"self.refresh_time == {self.refresh_time}")

--- a/leaguecog/zilean.py
+++ b/leaguecog/zilean.py
@@ -27,7 +27,9 @@ class Zilean(MixinMeta):
     #       this will pick up new users that registered during
     #           the last sleep window
     async def calculate_cooldown(self):
-        total_registered_users = 0
+        # start with total_registered_users = 1 else refresh timer
+        #   will default to zero
+        total_registered_users = 1
         guilds = await self.config.all_guilds()
 
         log.info(f"guilds == {guilds}")

--- a/leaguecog/zilean.py
+++ b/leaguecog/zilean.py
@@ -25,6 +25,7 @@ class Zilean(MixinMeta):
     """
 
     async def calculate_cooldown(self):
+        log.debug("Calculating cooldown...")
         # start with total_registered_users == 1 else refresh timer defaults to 0s
         total_registered_users = 1
         guilds = await self.config.all_guilds()
@@ -34,14 +35,12 @@ class Zilean(MixinMeta):
             poll_matches = await self.config.guild(guild).poll_games()
             if poll_matches:
                 users_in_guild = await self.config.all_members(guild=guild)
-                log.info(f"users_in_guild = {users_in_guild}")
             # get the length of the guild dictionary and add it to your total_registered_users
             total_registered_users += len(users_in_guild)
 
         # subtract the 1 from the beginning to get an accurate count
         #   i.e. if you just have one user, calculate for 1 user instead of 2
         total_registered_users -= 1
-        log.info(f"total_registered_users == {total_registered_users}")
 
         # leave bandwidth for some non-looping functions like set-summoner
         #   and account for multiple requests in each loop
@@ -53,4 +52,6 @@ class Zilean(MixinMeta):
             ((120 / (100 * overhead_ratio)) * total_registered_users) * reqs_per_loop,
             2,  # round to 2 decimal places
         )
-        log.info(f"cooldown == {self.cooldown}")
+        log.debug(
+            f"total registered users = {total_registered_users}, refresh timer cooldown = {self.cooldown}s"
+        )

--- a/leaguecog/zilean.py
+++ b/leaguecog/zilean.py
@@ -53,10 +53,11 @@ class Zilean(MixinMeta):
         # -------------------------------------------------- = seconds between each loop
         #      (  100 requests * overhead ratio )
 
-        self.cooldown = round(
+        cooldown = round(
             ((120 * total_registered_users * reqs_per_loop) / (100 * overhead_ratio)),
             2,  # round to 2 decimal places
         )
+        await self.config.refresh_timer.set(cooldown)
         log.debug(
-            f"total registered users = {total_registered_users}, refresh timer cooldown = {self.cooldown}s"
+            f"total registered users = {total_registered_users}, refresh timer cooldown = {cooldown}s"
         )

--- a/leaguecog/zilean.py
+++ b/leaguecog/zilean.py
@@ -26,7 +26,7 @@ class Zilean(MixinMeta):
     #   and then every time it loops through all the users
     #       this will pick up new users that registered during
     #           the last sleep window
-    async def calculate_refresh_interval(self, config):
+    async def calculate_cooldown(self):
         total_registered_users = 0
         guilds = await self.config.all_guilds()
 
@@ -46,7 +46,5 @@ class Zilean(MixinMeta):
         overhead_ratio = 0.75
         reqs_per_loop = 3
 
-        self.refresh_time = (
-            (120 / (100 * overhead_ratio)) * total_registered_users
-        ) * reqs_per_loop
-        log.info(f"self.refresh_time == {self.refresh_time}")
+        cooldown = ((120 / (100 * overhead_ratio)) * total_registered_users) * reqs_per_loop
+        log.info(f"cooldown == {cooldown}")

--- a/leaguecog/zilean.py
+++ b/leaguecog/zilean.py
@@ -46,5 +46,5 @@ class Zilean(MixinMeta):
         overhead_ratio = 0.75
         reqs_per_loop = 3
 
-        cooldown = ((120 / (100 * overhead_ratio)) * total_registered_users) * reqs_per_loop
-        log.info(f"cooldown == {cooldown}")
+        self.cooldown = ((120 / (100 * overhead_ratio)) * total_registered_users) * reqs_per_loop
+        log.info(f"(Zilean) self.cooldown == {self.cooldown}")

--- a/leaguecog/zilean.py
+++ b/leaguecog/zilean.py
@@ -25,23 +25,22 @@ class Zilean(MixinMeta):
     """
 
     async def calculate_cooldown(self):
-        # start with total_registered_users = 1 else refresh timer
-        #   will default to zero
+        # start with total_registered_users == 1 else refresh timer defaults to 0s
         total_registered_users = 1
         guilds = await self.config.all_guilds()
 
-        log.info(f"guilds == {guilds}")
-
         for guildId in guilds:
-            log.info(f"guildId == {guildId}")
             guild = await self.bot.fetch_guild(guildId)
             poll_matches = await self.config.guild(guild).poll_games()
-            log.info(f"poll_matches == {poll_matches}")
             if poll_matches:
-                registered_users_in_guild = await self.config.all_members(guild=guild)
-                log.info(f"registered_users_in_guild = {registered_users_in_guild}")
-            total_registered_users += registered_users_in_guild
+                users_in_guild = await self.config.all_members(guild=guild)
+                log.info(f"users_in_guild = {users_in_guild}")
+            # get the length of the guild dictionary and add it to your total_registered_users
+            total_registered_users += len(users_in_guild)
 
+        # subtract the 1 from the beginning to get an accurate count
+        #   i.e. if you just have one user, calculate for 1 user instead of 2
+        total_registered_users -= 1
         log.info(f"total_registered_users == {total_registered_users}")
 
         # leave bandwidth for some non-looping functions like set-summoner
@@ -49,8 +48,9 @@ class Zilean(MixinMeta):
         overhead_ratio = 0.75
         reqs_per_loop = 3
 
+        # calculate the refresh timer, and round it off to 2 decimal places
         self.cooldown = round(
             ((120 / (100 * overhead_ratio)) * total_registered_users) * reqs_per_loop,
-            2,  # decimal places
+            2,  # round to 2 decimal places
         )
-        log.info(f"zilean cooldown == {self.cooldown}")
+        log.info(f"cooldown == {self.cooldown}")

--- a/leaguecog/zilean.py
+++ b/leaguecog/zilean.py
@@ -48,8 +48,13 @@ class Zilean(MixinMeta):
         reqs_per_loop = 3
 
         # calculate the refresh timer, and round it off to 2 decimal places
+
+        #  ( 120 seconds * # of users * requests per loop )
+        # -------------------------------------------------- = seconds between each loop
+        #      (  100 requests * overhead ratio )
+
         self.cooldown = round(
-            ((120 / (100 * overhead_ratio)) * total_registered_users) * reqs_per_loop,
+            ((120 * total_registered_users * reqs_per_loop) / (100 * overhead_ratio)),
             2,  # round to 2 decimal places
         )
         log.debug(


### PR DESCRIPTION
* calculates the number of registered users across all guilds for the bot on each check games loop
* closes #25 

Calculated as follows:

```
 120 seconds * # of users * requests per loop      
---------------------------------------------- = seconds between each loop
        100 requests * overhead ratio
```
examples:

```
 120 seconds * 2 users * 3 requests per loop      
---------------------------------------------- = 14.4 seconds between each loop
        100 requests * 0.75
```

```
 120 seconds * 5 users * 3 requests per loop      
---------------------------------------------- = 24 seconds between each loop
        100 requests * 0.75
```

```
 120 seconds * 20 users * 3 requests per loop      
----------------------------------------------- = 96 seconds between each loop
         100 requests * 0.75
```