### PR TITLE
Change black pre-commit hook to allow for python3.9

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@
         rev: 22.6.0
         hooks:
           - id: black
-            language_version: python3.8
+            language_version: python3
       - repo: https://gitlab.com/pycqa/flake8
         rev: 3.9.2
         hooks:


### PR DESCRIPTION
* changing `language_version` to `python3` allows for development within a Python3.9 environment
* see this [stackoverflow question](https://stackoverflow.com/a/69465958/13615436) for details