### PR TITLE
Fixed bug where refresh_time could be 0 seconds

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@
         rev: 22.6.0
         hooks:
           - id: black
-            language_version: python3.8
+            language_version: python3
       - repo: https://gitlab.com/pycqa/flake8
         rev: 3.9.2
         hooks:

--- a/leaguecog/blitzcrank.py
+++ b/leaguecog/blitzcrank.py
@@ -7,13 +7,13 @@ from lib2to3.pytree import Base
 from redbot.core import Config
 from xml.dom import NotFoundErr
 
-from .mixinmeta import MixinMeta
+from .mixinmeta import MixInMeta
 
 
 log = logging.getLogger("red.creamy-cogs.league")
 
 
-class Blitzcrank(MixinMeta):
+class Blitzcrank(MixInMeta):
     """
     'The time of man has come to an end.'
 

--- a/leaguecog/ezreal.py
+++ b/leaguecog/ezreal.py
@@ -2,13 +2,13 @@ from datetime import datetime
 import discord
 import logging
 
-from .mixinmeta import MixinMeta
+from .mixinmeta import MixInMeta
 
 
 log = logging.getLogger("red.creamy-cogs.league")
 
 
-class Ezreal(MixinMeta):
+class Ezreal(MixInMeta):
     """
     'Lot of good mages out there. None of them are this hot!'
 

--- a/leaguecog/mixinmeta.py
+++ b/leaguecog/mixinmeta.py
@@ -6,7 +6,7 @@ from redbot.core import Config, commands
 from redbot.core.bot import Red
 
 
-class MixinMeta(ABC):
+class MixInMeta(ABC):
     """
     Base class for well behaved type hint detection with composite class.
     Basically, to keep developers sane when not all attributes are defined in each mixin.

--- a/leaguecog/zilean.py
+++ b/leaguecog/zilean.py
@@ -45,7 +45,7 @@ class Zilean(MixinMeta):
 
         # if no one has registered, set total_registered_users to 1
         #   this way, refresh_timer doesn't get set to 0 seconds
-        if total_registered_users < 1:
+        if not total_registered_users:
             total_registered_users = 1
 
         # leave bandwidth for some non-looping functions like set-summoner

--- a/leaguecog/zilean.py
+++ b/leaguecog/zilean.py
@@ -1,13 +1,13 @@
 import asyncio
 import logging
 
-from .mixinmeta import MixinMeta
+from .mixinmeta import MixInMeta
 
 
 log = logging.getLogger("red.creamy-cogs.league")
 
 
-class Zilean(MixinMeta):
+class Zilean(MixInMeta):
     """
     'All in good time.'
 

--- a/leaguecog/zilean.py
+++ b/leaguecog/zilean.py
@@ -40,7 +40,9 @@ class Zilean(MixinMeta):
 
         # subtract the 1 from the beginning to get an accurate count
         #   i.e. if you just have one user, calculate for 1 user instead of 2
-        total_registered_users -= 1
+        #       and make sure that total_registered_users isn't <1
+        if total_registered_users > 1:
+            total_registered_users -= 1
 
         # leave bandwidth for some non-looping functions like set-summoner
         #   and account for multiple requests in each loop

--- a/leaguecog/zilean.py
+++ b/leaguecog/zilean.py
@@ -40,8 +40,8 @@ class Zilean(MixinMeta):
             poll_matches = await self.config.guild(guild).poll_games()
             if poll_matches:
                 users_in_guild = await self.config.all_members(guild=guild)
-            # get the length of the guild dictionary and add it to your total_registered_users
-            total_registered_users += len(users_in_guild)
+                # get the length of the guild dictionary and add it to your total_registered_users
+                total_registered_users += len(users_in_guild)
 
         # if no one has registered, set total_registered_users to 1
         #   this way, refresh_timer doesn't get set to 0 seconds


### PR DESCRIPTION
* `Zilean` could get `total_registered_users = 0` if no one had registered with `[p]league set-summoner`
* this would set `refresh_timer` to 0 seconds
* now, lowest possible `total_registered_users` is 1