### PR TITLE
Added error handling for toggle-polling

### DIFF
--- a/leaguecog/leaguecog.py
+++ b/leaguecog/leaguecog.py
@@ -368,14 +368,14 @@ class LeagueCog(
                     self,
                     title="TOGGLE-POLLING: INVALID STATE",
                     msg=(
-                        f"`{state}` is not a valid `state` for `toggle-polling`.\n"
-                        "Valid states: `on`, `true`, `off`, `false` (case-insensitive).\n"
-                        "Omit the argument to toggle the opposite of the current status.\n"
+                        f"`{state}` is not a valid state for `toggle-polling`\n\n"
+                        "Valid states: `on`, `true`, `off`, `false` (case-insensitive)\n\n"
+                        "Omit the state to toggle the opposite of the current state\n\n"
                         "Example usage:\n"
                         # TODO get the actual ping for the example message
-                        "`[p]league toggle-polling on`\n"
-                        "`[p]league toggle-polling False"
-                        "`[p]league toggle-polling`"
+                        f"`{ctx.clean_prefix}league toggle-polling on`\n"
+                        f"`{ctx.clean_prefix}league toggle-polling False`\n"
+                        f"`{ctx.clean_prefix}league toggle-polling`"
                     ),
                 )
                 await ctx.send(embed=invalid_toggle_embed)

--- a/leaguecog/leaguecog.py
+++ b/leaguecog/leaguecog.py
@@ -362,6 +362,24 @@ class LeagueCog(
                 state_bool = True
             elif state in ("off", "false"):
                 state_bool = False
+            else:
+                # handle user input that isn't valid
+                invalid_toggle_embed = await Ezreal.build_embed(
+                    self,
+                    title="TOGGLE-POLLING: INVALID STATE",
+                    msg=(
+                        f"`{state}` is not a valid `state` for `toggle-polling`.\n"
+                        "Valid states: `on`, `true`, `off`, `false` (case-insensitive).\n"
+                        "Omit the argument to toggle the opposite of the current status.\n"
+                        "Example usage:\n"
+                        # TODO get the actual ping for the example message
+                        "`[p]league toggle-polling on`\n"
+                        "`[p]league toggle-polling False"
+                        "`[p]league toggle-polling`"
+                    ),
+                )
+                await ctx.send(embed=invalid_toggle_embed)
+                return
         else:
             # get the current state of poll_user_games, and set the opposite
             current_state = await self.config.user(userId).poll_user_games()

--- a/leaguecog/leaguecog.py
+++ b/leaguecog/leaguecog.py
@@ -372,7 +372,6 @@ class LeagueCog(
                         "Valid states: `on`, `true`, `off`, `false` (case-insensitive)\n\n"
                         "Omit the state to toggle the opposite of the current state\n\n"
                         "Example usage:\n"
-                        # TODO get the actual ping for the example message
                         f"`{ctx.clean_prefix}league toggle-polling on`\n"
                         f"`{ctx.clean_prefix}league toggle-polling False`\n"
                         f"`{ctx.clean_prefix}league toggle-polling`"


### PR DESCRIPTION
* handles bad user input for `state` arg in `toggle-polling` rather than silently failing
* sends an embed with example usage
* should have been part of original PR for #18 